### PR TITLE
Setup fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 
 setup(
     name='rllab',
+    packages=[package for package in find_packages()
+                if package.startswith('rllab')],
     version='0.1.0',
-    packages=['rllab'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # setup.py
-from setuptools import setup
+from setuptools import setup,find_packages
 
 setup(
     name='rllab',


### PR DESCRIPTION
It is a very, very simple addition to the setup.py. It enables pip install git+https://github.com/rll/rllab to install the other packages under rllab (tested on anaconda without this fix and they would not install).