### PR TITLE
install mujoco-v0.5.7 from source

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
         - pyzmq
         - tqdm
         - msgpack-python
-        - mujoco_py
+        - git+https://github.com/inksci/mujoco-py-v0.5.7.git
         - cached_property
         - line_profiler
         - cloudpickle


### PR DESCRIPTION
Install mujoco_py with pip install mujoco_py always make error. A better way is installing it from the source code.