### PR TITLE
Enable more than one MjViewer instance at a time

### DIFF
--- a/rllab/mujoco_py/mjviewer.py
+++ b/rllab/mujoco_py/mjviewer.py
@@ -20,7 +20,7 @@ def _glfw_error_callback(e, d):
 
 class MjViewer(object):
 
-    def __init__(self, visible=True, init_width=500, init_height=500, go_fast=False):
+    def __init__(self, visible=True, init_width=500, init_height=500, go_fast=False, title="Simulate"):
         """
         Set go_fast=True to run at full speed instead of waiting for the 60 Hz monitor refresh
         init_width and init_height set window size. On Mac Retina displays, they are in nominal
@@ -43,6 +43,7 @@ class MjViewer(object):
         self.window = None
         self.model = None
         self.gui_lock = Lock()
+        self.title = title
 
         # framebuffer objects
         self._fbo = None
@@ -176,7 +177,7 @@ class MjViewer(object):
         if refresh_rate >= 100:
             glfw.window_hint(glfw.STEREO, 1)
             window = glfw.create_window(
-                self.init_width, self.init_height, "Simulate", None, None)
+                self.init_width, self.init_height, self.title, None, None)
             if window:
                 stereo_available = True
 
@@ -184,7 +185,7 @@ class MjViewer(object):
         if not window:
             glfw.window_hint(glfw.STEREO, 0)
             window = glfw.create_window(
-                self.init_width, self.init_height, "Simulate", None, None)
+                self.init_width, self.init_height, self.title, None, None)
 
         if not window:
             glfw.terminate()

--- a/rllab/mujoco_py/mjviewer.py
+++ b/rllab/mujoco_py/mjviewer.py
@@ -90,6 +90,10 @@ class MjViewer(object):
     def render(self):
         if not self.data:
             return
+
+        # Make the window's context current
+        glfw.make_context_current(self.window)
+        
         self.gui_lock.acquire()
         rect = self.get_rect()
         arr = (ctypes.c_double*3)(0, 0, 0)


### PR DESCRIPTION
This PR contains a feature and a bug fix which allow an rllab user to open more than one MjViewer window at a time.

**Bug fix**
MjViewer assumes that, once set during MjViewer.start(), the glfw context never changes. This is not true for multiple windows, which share a global glfw context. Each window needs to switch the glfw context to its own window during rendering.

**Feature**
Add a kwarg to MjViewer which allows the user to change the window title (useful if you're opening more than one).

Both of these could be solved by upgrading mujoco-py to 1.0+, a project I may take on later. For now, these fixes suffice.