### PR TITLE
Remove chainer from enviroment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -54,7 +54,6 @@ dependencies:
         - git+https://github.com/neocxi/prettytensor.git
         - jupyter
         - progressbar2
-        - chainer==1.18.0
         - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.0.1-cp35-cp35m-linux_x86_64.whl; 'linux' in sys_platform
         - https://storage.googleapis.com/tensorflow/mac/gpu/tensorflow_gpu-1.0.1-py3-none-any.whl; sys_platform == 'darwin'
         - numpy-stl==2.2.0


### PR DESCRIPTION
chainer setup is broken (on Ubuntu 16.04, at least), and the chainer devs direct users to newer versions, because v1.18.0 is unsupported. See https://github.com/cupy/cupy/issues/886.

I can find no actual dependencies to chainer in the main rllab repo. If someone has some downstream code with a hard chainer dependency, they're welcome to submit a (working) PR to add it back in.

Addresses:
* https://github.com/rll/rllab/issues/182
* https://github.com/rll/rllab/issues/212