### PR TITLE
TensorFlow: Symbolic entropy for DiagonalGaussian

### DIFF
--- a/sandbox/rocky/tf/distributions/diagonal_gaussian.py
+++ b/sandbox/rocky/tf/distributions/diagonal_gaussian.py
@@ -92,6 +92,10 @@ class DiagonalGaussian(Distribution):
         log_stds = dist_info["log_std"]
         return np.sum(log_stds + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)
 
+    def entropy_sym(self, dist_info_var):
+        log_std_var = dist_info_var["log_std"]
+        return tf.reduce_sum(log_std_var + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)
+
     @property
     def dist_info_specs(self):
         return [("mean", (self.dim,)), ("log_std", (self.dim,))]


### PR DESCRIPTION
Adds a symbolic entropy operation to the DiagonalGaussian implementation in the TensorFlow tree. This is equivalent to https://github.com/rll/rllab/blob/master/rllab/distributions/diagonal_gaussian.py#L89