### PR TITLE
Fixes type mismatch issue: https://github.com/rll/rllab/issues/224

### DIFF
--- a/rllab/optimizers/conjugate_gradient_optimizer.py
+++ b/rllab/optimizers/conjugate_gradient_optimizer.py
@@ -143,7 +143,7 @@ class ConjugateGradientOptimizer(Serializable):
         if self._subsample_factor < 1:
             n_samples = len(inputs[0])
             inds = np.random.choice(
-                n_samples, n_samples * self._subsample_factor, replace=False)
+                n_samples, int(n_samples * self._subsample_factor), replace=False)
             subsample_inputs = tuple([x[inds] for x in inputs])
         else:
             subsample_inputs = inputs


### PR DESCRIPTION
It used to throw the following error on line 146 of ```optimizers/conjugate_gradient_optimizer.py``` of **```rllab:py2```** branch while trying to run ```trpo_cartpole.py``` in that branch. 

```bash
Traceback (most recent call last):
  File "trpo_cartpole.py", line 27, in <module>
    algo.train()
  File "/home/rkaushik/projects/cloned_libs/rllab/rllab/algos/batch_polopt.py", line 253, in train
    self.optimize_policy(itr, samples_data)
  File "/home/rkaushik/projects/cloned_libs/rllab/rllab/algos/npo.py", line 109, in optimize_policy
    self.optimizer.optimize(all_input_values)
  File "/home/rkaushik/projects/cloned_libs/rllab/rllab/optimizers/conjugate_gradient_optimizer.py", line 146, in optimize
    n_samples, (n_samples * self._subsample_factor), replace=False)
  File "mtrand.pyx", line 1176, in mtrand.RandomState.choice (numpy/random/mtrand/mtrand.c:18822)
TypeError: 'float' object cannot be interpreted as an index 
```
This resolves this issue by typecasting (to int) the 2nd parameter of ```np.random.choice(...)``` call like this. 

```python
inds = np.random.choice(
                n_samples, int(n_samples * self._subsample_factor), replace=False)
``` 
